### PR TITLE
Feature/6 optional and nullable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Allow using the `.optional()` modifier on `.nullable()` types
+- Add documentation for [nullable and optional modifier](doc/modifiers/nullability.md)
 - Add new type for DateTime
 
 ## 0.3.0 - 2025-06-16

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ void main() {
 - [Features](#features)
 - [Basic Usage](#basic-usage)
 - [Validation & refine](#validation--refine)
+- [Nullable & optional values](#nullable--optional-values)
 - [Localization & Custom Errors](#localization--custom-errors)
 - [Additional information](#additional-information)
 
@@ -267,6 +268,14 @@ void main() {
   print(result.issueSummary);
 }
 ```
+
+## Nullable & optional values
+
+In Dart, unlike JavaScript, there is no concept of `undefined` value. However, when parsing `ZObject` from `Map<String, dynamic>`, a missing key (`!map.containsKey('key')`) is the Dart equivalent of `undefined`. To explicitly allow missing keys, ZodArt provides the `.optional()` modifier.
+
+For all other schemas like `ZString`, `ZInt`, etc., there is no concept of a "missing" value outside a `ZObject`. In this context, the `.optional()` modifier has no semantic effect and is treated as **equivalent** to `.nullable()`.
+
+See more at [nullable modifier doc](doc/modifiers/nullability.md).
 
 ## Localization & Custom Errors
 

--- a/doc/modifiers/nullability.md
+++ b/doc/modifiers/nullability.md
@@ -1,0 +1,28 @@
+## ZObject Parsing (Map fields)
+
+In Dart, unlike JavaScript, there is no concept of `undefined` value. However, when parsing a `Map<String, dynamic>`, a missing key (`!map.containsKey('key')`) is the Dart equivalent of `undefined`. To explicitly allow missing keys, ZodArt provides the `.optional()` modifier.
+
+- `.nullable()` - allows the field value to be `null`
+- `.optional()` - allows the field to be either `null` or **missing from the map**
+
+| Field value             | `.nullable()` | `.optional()` | Result                 |
+| ----------------------- | ------------- | ------------- | ---------------------- |
+| null                    | ❌            | ❌            | ❌ ParseError          |
+| null                    | ❌            | ✅            | ✅ ParseSuccess (null) |
+| null                    | ✅            | ❌            | ✅ ParseSuccess (null) |
+| null                    | ✅            | ✅            | ✅ ParseSuccess (null) |
+| !map.containsKey('key') | ❌            | ❌            | ❌ ParseError          |
+| !map.containsKey('key') | ❌            | ✅            | ✅ ParseSuccess (null) |
+| !map.containsKey('key') | ✅            | ❌            | ❌ ParseError          |
+| !map.containsKey('key') | ✅            | ✅            | ✅ ParseSuccess (null) |
+
+## Other Types Parsing
+
+For all other schemas like `ZString`, `ZInt`, etc., there is no concept of a "missing" value outside a `ZObject`. Values passed directly to `.parse()` are always either `null` or a `concrete value`. In this context, the `.optional()` modifier has no semantic effect and is treated as **equivalent** to `.nullable()`:
+
+| Field value | `.nullable()` | `.optional()` | Result                 |
+| ----------- | ------------- | ------------- | ---------------------- |
+| null        | ❌            | ❌            | ❌ ParseError          |
+| null        | ❌            | ✅            | ✅ ParseSuccess (null) |
+| null        | ✅            | ❌            | ✅ ParseSuccess (null) |
+| null        | ✅            | ✅            | ✅ ParseSuccess (null) |

--- a/lib/src/types/z_nullable_array.dart
+++ b/lib/src/types/z_nullable_array.dart
@@ -15,6 +15,9 @@ class ZNullableArray<T> extends ZBase<List<T>?> implements ZTransformations<List
 
   ZNullableArray<T> _addRule(Rule<List<T>> r) => ZNullableArray._withConfig(_config.addRule(RuleArray(r)));
 
+  /// Enable omitting this value. All rules will be skipped if the value is missing.
+  ZNullableArray<T> optional() => ZNullableArray._withConfig(_config.makeOptional());
+
   @override
   ZNullableArray<T> refine(Refiner<List<T>> refiner, {String? message, String? code}) =>
       _addRule(refineRule(refiner, message: message, code: code));

--- a/lib/src/types/z_nullable_bool.dart
+++ b/lib/src/types/z_nullable_bool.dart
@@ -18,6 +18,9 @@ class ZNullableBool extends ZBase<bool?> implements ZTransformations<bool, bool?
 
   ZNullableBool _addRule(Rule<bool> r) => ZNullableBool._withConfig(_config.addRule(RuleBool(r)));
 
+  /// Enable omitting this value. All rules will be skipped if the value is missing.
+  ZNullableBool optional() => ZNullableBool._withConfig(_config.makeOptional());
+
   @override
   ZNullableBool refine(Refiner<bool> refiner, {String? message, String? code}) =>
       _addRule(refineRule(refiner, message: message, code: code));

--- a/lib/src/types/z_nullable_date_time.dart
+++ b/lib/src/types/z_nullable_date_time.dart
@@ -28,6 +28,9 @@ class ZNullableDateTime extends ZBase<DateTime?> implements ZTransformations<Dat
   /// Skips the validation if the value is `null`.
   ZNullableDateTime max(DateTime max) => _addRule(maxDateTimeRule(max));
 
+  /// Enable omitting this value. All rules will be skipped if the value is missing.
+  ZNullableDateTime optional() => ZNullableDateTime._withConfig(_config.makeOptional());
+
   @override
   ZNullableDateTime refine(Refiner<DateTime> refiner, {String? message, String? code}) =>
       _addRule(refineRule(refiner, message: message, code: code));

--- a/lib/src/types/z_nullable_double.dart
+++ b/lib/src/types/z_nullable_double.dart
@@ -24,6 +24,9 @@ class ZNullableDouble extends ZBase<double?> implements ZTransformations<double,
   /// Skips the validation if the value is `null`.
   ZNullableDouble max(double max) => _addRule(maxNumRule(max));
 
+  /// Enable omitting this value. All rules will be skipped if the value is missing.
+  ZNullableDouble optional() => ZNullableDouble._withConfig(_config.makeOptional());
+
   @override
   ZNullableDouble refine(Refiner<double> refiner, {String? message, String? code}) =>
       _addRule(refineRule(refiner, message: message, code: code));

--- a/lib/src/types/z_nullable_int.dart
+++ b/lib/src/types/z_nullable_int.dart
@@ -24,6 +24,9 @@ class ZNullableInt extends ZBase<int?> implements ZTransformations<int, int?> {
   /// Skips the validation if the value is `null`.
   ZNullableInt max(int max) => _addRule(maxNumRule(max));
 
+  /// Enable omitting this value. All rules will be skipped if the value is missing.
+  ZNullableInt optional() => ZNullableInt._withConfig(_config.makeOptional());
+
   @override
   ZNullableInt refine(Refiner<int> refiner, {String? message, String? code}) =>
       _addRule(refineRule(refiner, message: message, code: code));

--- a/lib/src/types/z_nullable_object.dart
+++ b/lib/src/types/z_nullable_object.dart
@@ -25,6 +25,9 @@ class ZNullableObject<T> extends ZBase<T?> implements ZTransformations<T, T?> {
 
   ZNullableObject<T> _addRule(Rule<T> r) => ZNullableObject<T>._withConfig(_config.addRule(RuleObject(r)));
 
+  /// Enable omitting this value. All rules will be skipped if the value is missing.
+  ZNullableObject<T> optional() => ZNullableObject._withConfig(_config.makeOptional());
+
   @override
   ZNullableObject<T> refine(Refiner<T> refiner, {String? message, String? code}) =>
       _addRule(refineRule(refiner, message: message, code: code));

--- a/lib/src/types/z_nullable_string.dart
+++ b/lib/src/types/z_nullable_string.dart
@@ -42,6 +42,9 @@ class ZNullableString extends ZBase<String?> implements ZTransformations<String,
   ZNullableDateTime toDateTime() =>
       ZNullableDateTime._withConfig(_config.addTransformation(TransformStringToDateTime(stringToDateTime)));
 
+  /// Enable omitting this value. All rules will be skipped if the value is missing.
+  ZNullableString optional() => ZNullableString._withConfig(_config.makeOptional());
+
   @override
   ZNullableString refine(Refiner<String> refiner, {String? message, String? code}) =>
       _addRule(refineRule(refiner, message: message, code: code));

--- a/test/src/types/z_array_test.dart
+++ b/test/src/types/z_array_test.dart
@@ -103,6 +103,21 @@ void main() {
           ZArray(ZString()).optional(),
         );
       });
+      group('nullable -> optional', () {
+        testInputs(
+          (
+            validInputs: [
+              ...baseValidInputs,
+              (
+                input: null,
+                expected: null,
+              ),
+            ],
+            invalidInputs: baseInvalidInputs,
+          ),
+          ZArray(ZString()).nullable().optional(),
+        );
+      });
     });
   });
 

--- a/test/src/types/z_bool_test.dart
+++ b/test/src/types/z_bool_test.dart
@@ -48,6 +48,18 @@ void main() {
           ZBool().optional(),
         );
       });
+      group('nullable -> optional', () {
+        testInputs(
+          (
+            validInputs: [
+              ...baseValidInputs,
+              (input: null, expected: null),
+            ],
+            invalidInputs: baseInvalidInputs,
+          ),
+          ZBool().nullable().optional(),
+        );
+      });
     });
   });
 

--- a/test/src/types/z_date_time_test.dart
+++ b/test/src/types/z_date_time_test.dart
@@ -53,6 +53,18 @@ void main() {
           ZDateTime().optional(),
         );
       });
+      group('nullable -> optional', () {
+        testInputs(
+          (
+            validInputs: [
+              ...baseValidInputs,
+              (input: null, expected: null),
+            ],
+            invalidInputs: baseInvalidInputs,
+          ),
+          ZDateTime().nullable().optional(),
+        );
+      });
     });
   });
   group('min', () {

--- a/test/src/types/z_double_test.dart
+++ b/test/src/types/z_double_test.dart
@@ -55,6 +55,18 @@ void main() {
           ZDouble().optional(),
         );
       });
+      group('nullable -> optional', () {
+        testInputs(
+          (
+            validInputs: [
+              ...baseValidInputs,
+              (input: null, expected: null),
+            ],
+            invalidInputs: baseInvalidInputs,
+          ),
+          ZDouble().nullable().optional(),
+        );
+      });
     });
   });
   group('min', () {

--- a/test/src/types/z_int_test.dart
+++ b/test/src/types/z_int_test.dart
@@ -53,6 +53,18 @@ void main() {
           ZInt().optional(),
         );
       });
+      group('nullable -> optional', () {
+        testInputs(
+          (
+            validInputs: [
+              ...baseValidInputs,
+              (input: null, expected: null),
+            ],
+            invalidInputs: baseInvalidInputs,
+          ),
+          ZInt().nullable().optional(),
+        );
+      });
     });
   });
 

--- a/test/src/types/z_object_test.dart
+++ b/test/src/types/z_object_test.dart
@@ -154,6 +154,21 @@ void main() {
           ZObject<TestObject>.withMapper(schema, fromJson: testObjectMapper).optional(),
         );
       });
+      group('nullable -> optional', () {
+        testInputs(
+          (
+            validInputs: [
+              ...baseValidInputs,
+              (
+                input: null,
+                expected: null,
+              ),
+            ],
+            invalidInputs: baseInvalidInputs,
+          ),
+          ZObject<TestObject>.withMapper(schema, fromJson: testObjectMapper).nullable().optional(),
+        );
+      });
     });
   });
 

--- a/test/src/types/z_string_test.dart
+++ b/test/src/types/z_string_test.dart
@@ -54,6 +54,18 @@ void main() {
           ZString().optional(),
         );
       });
+      group('nullable -> optional', () {
+        testInputs(
+          (
+            validInputs: [
+              ...baseValidInputs,
+              (input: null, expected: null),
+            ],
+            invalidInputs: baseInvalidInputs,
+          ),
+          ZString().nullable().optional(),
+        );
+      });
     });
   });
   group('min', () {


### PR DESCRIPTION
## 📌 Summary

Allow to modify `nullable` types to be `optional`.
 
## ✅ Changes

- [x] Add `.optional()` modifier for all nullable types
- [x] Add documentation for nullable / optional

## 📝 Changelog

Changelog updated:

- [x] Yes
- [ ] No

## 🔍 Related Issues

<!-- Link to related issues, e.g. -->

Closes #6 

## 🧪 Testing

- [x] Unit tests added/updated

<!-- Explain testing strategy if needed -->

> Example: Passed all unit tests.

## 🚨 Breaking Changes

- [ ] Yes
- [x] No

If yes, describe:

## 📸 Screenshots / Videos (Optional)

None

<!-- Add before/after screenshots or videos if relevant -->

## 📓 Notes for Reviewers (Optional)

None

<!-- Any special instructions or things to look out for -->
