### PR TITLE
Feature/59 zarray add min max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [UNRELEASED]
 
+- add .min() and .max() methods for ZArray
 - update build package to 3.0.2 and source_gen to 3.1.0
 
 ## 1.0.0 - 2025-08-19

--- a/doc/types/types.md
+++ b/doc/types/types.md
@@ -9,6 +9,9 @@ classDiagram
     }
 
     class ZArray~T~ {
+        + min(min)
+        + max(max)
+
         + nullable() ZNullableArray
         + optional() ZNullableArray
 
@@ -104,6 +107,9 @@ classDiagram
     }
 
     class ZNullableArray~T~ {
+        + min(min)
+        + max(max)
+
         + toStr(t)
         + toArray<NewType>(t)
 

--- a/lib/src/modifiers/rules.dart
+++ b/lib/src/modifiers/rules.dart
@@ -1,42 +1,79 @@
 import '../base/base.dart';
 
+/// Returns the String length
+int getStrLength(String val) => val.length;
+
+/// Returns the length of a T  Iterable
+int getIterableLength<T>(Iterable<T> val) => val.length;
+
+/// Function which returns length of T
+typedef LengthGetter<T> = int Function(T);
+
+/// Builds a rule that checks a value of type [T] has length ≥ `min`.
+///
+/// Uses [lengthGetter] to extract the length.
+/// Returns success if valid, otherwise [ZIssueMinLengthNotMet].
+ResRule<T> Function(int min) minLengthRule<T>(LengthGetter<T> lengthGetter) {
+  return (int min) {
+    return (T val) {
+      final length = lengthGetter(val);
+
+      return length >= min
+          ? ZRes.success(val)
+          : ZRes.errorSingleIssue(
+              ZIssueMinLengthNotMet(
+                actualLength: length,
+                minLength: min,
+              ),
+            );
+    };
+  };
+}
+
+/// Builds a rule that checks a value of type [T] has length ≤ `max`.
+///
+/// Uses [lengthGetter] to extract the length.
+/// Returns success if valid, otherwise [ZIssueMaxLengthExceeded].
+ResRule<T> Function(int max) maxLengthRule<T>(LengthGetter<T> lengthGetter) {
+  return (int max) {
+    return (T val) {
+      final length = lengthGetter(val);
+
+      return length <= max
+          ? ZRes.success(val)
+          : ZRes.errorSingleIssue(
+              ZIssueMaxLengthExceeded(
+                actualLength: length,
+                maxLength: max,
+              ),
+            );
+    };
+  };
+}
+
 /// Returns a [ResRule] of type `ResRule<String>`, which checks minimum string length.
 ///
 /// The returned rule will succeed if the input string's length is greater than or equal to [min],
 /// otherwise it will return a [ZIssueMinLengthNotMet].
-ResRule<String> minStrLengthRule(int min) {
-  return (String val) {
-    final length = val.length;
-
-    return length >= min
-        ? ZRes.success(val)
-        : ZRes.errorSingleIssue(
-            ZIssueMinLengthNotMet(
-              actualLength: length,
-              minLength: min,
-            ),
-          );
-  };
-}
+ResRule<String> minStrLengthRule(int min) => minLengthRule(getStrLength)(min);
 
 /// Returns a [ResRule] of type `ResRule<String>`, which checks maximum string length.
 ///
 /// The returned rule will succeed if the input string's length is less than or equal to [max],
 /// otherwise it will return a [ZIssueMaxLengthExceeded].
-ResRule<String> maxStrLengthRule(int max) {
-  return (String val) {
-    final length = val.length;
+ResRule<String> maxStrLengthRule(int max) => maxLengthRule(getStrLength)(max);
 
-    return length <= max
-        ? ZRes.success(val)
-        : ZRes.errorSingleIssue(
-            ZIssueMaxLengthExceeded(
-              actualLength: length,
-              maxLength: max,
-            ),
-          );
-  };
-}
+/// Returns a [ResRule] of type `ResRule<Iterable<T>>`, which checks minimum iterable length.
+///
+/// The returned rule will succeed if the input iterable's length is greater than or equal to [min],
+/// otherwise it will return a [ZIssueMinLengthNotMet].
+ResRule<Iterable<T>> minIterableLengthRule<T>(int min) => minLengthRule(getIterableLength<T>)(min);
+
+/// Returns a [ResRule] of type `ResRule<Iterable<T>>`, which checks maximum iterable length.
+///
+/// The returned rule will succeed if the input iterable's length is less than or equal to [max],
+/// otherwise it will return a [ZIssueMaxLengthExceeded].
+ResRule<Iterable<T>> maxIterableLengthRule<T>(int max) => maxLengthRule(getIterableLength<T>)(max);
 
 /// Returns a [ResRule] of type `ResRule<T>`, which checks minimum number value.
 ///

--- a/lib/src/types/z_array.dart
+++ b/lib/src/types/z_array.dart
@@ -21,6 +21,16 @@ class ZArray<T> extends ZBase<List<T>> implements ZTransformations<List<T>, List
   /// such as after applying transformation or additional rules.
   ZArray._withConfig(super.config) : super._withConfig();
 
+  /// Adds a custom rule for Iterable (List) validation and returns a new `ZArray` instance.
+  ZArray<T> _addRule(ResRule<Iterable<T>> validation) =>
+      _validateBuildIn(constructor: ZArray<T>._withConfig, validation: validation);
+
+  /// Adds a rule to enforce that the array length must be greater than or equal to `min`.
+  ZArray<T> min(int min) => _addRule(minIterableLengthRule<T>(min));
+
+  /// Adds a rule to enforce that the array length must be less than or equal to `max`.
+  ZArray<T> max(int max) => _addRule(maxIterableLengthRule(max));
+
   /// Enable `null` value. All rules will be skipped for null values.
   ZNullableArray<T> nullable() => _nullable(constructor: ZNullableArray<T>._withConfig);
 

--- a/lib/src/types/z_nullable_array.dart
+++ b/lib/src/types/z_nullable_array.dart
@@ -14,6 +14,16 @@ class ZNullableArray<T> extends ZBase<List<T>?>
     implements ZTransformations<List<T>, List<T>?>, ZNullableTransformations<List<T>, List<T>?> {
   ZNullableArray._withConfig(super.config) : super._withConfig();
 
+  /// Adds a custom rule for Iterable (List) validation and returns a new `ZNullableArray` instance.
+  ZNullableArray<T> _addRule(ResRule<Iterable<T>> validation) =>
+      _validateBuildIn(constructor: ZNullableArray<T>._withConfig, validation: validation);
+
+  /// Adds a rule to enforce that the array length must be greater than or equal to `min`.
+  ZNullableArray<T> min(int min) => _addRule(minIterableLengthRule<T>(min));
+
+  /// Adds a rule to enforce that the array length must be less than or equal to `max`.
+  ZNullableArray<T> max(int max) => _addRule(maxIterableLengthRule(max));
+
   /// Enable omitting this value. All rules will be skipped if the value is missing.
   ZNullableArray<T> optional() => _optional(constructor: ZNullableArray<T>._withConfig);
 

--- a/test/src/types/z_array_test.dart
+++ b/test/src/types/z_array_test.dart
@@ -121,6 +121,102 @@ void main() {
     });
   });
 
+  group('min', () {
+    const min = 3;
+    const baseValidInputs = <ValidInput>[
+      (input: [1, 2, 3], expected: [1, 2, 3]),
+      (input: [1, 2, 3, 4], expected: [1, 2, 3, 4]),
+      (input: [1, 2, 3, 4, 5], expected: [1, 2, 3, 4, 5]),
+    ];
+    const baseInvalidInputs = <InvalidInput>[
+      (input: <int>[], expected: [ZIssueMinLengthNotMet(minLength: min, actualLength: 0)]),
+      (input: [1], expected: [ZIssueMinLengthNotMet(minLength: min, actualLength: 1)]),
+      (input: [1, 2], expected: [ZIssueMinLengthNotMet(minLength: min, actualLength: 2)]),
+    ];
+
+    group('required', () {
+      testInputs(
+        (
+          validInputs: baseValidInputs,
+          invalidInputs: baseInvalidInputs,
+        ),
+        ZArray(ZInt()).min(min),
+      );
+    });
+    group('nullable first', () {
+      testInputs(
+        (
+          validInputs: [
+            ...baseValidInputs,
+            (input: null, expected: null),
+          ],
+          invalidInputs: baseInvalidInputs,
+        ),
+        ZArray(ZInt()).nullable().min(min),
+      );
+    });
+    group('nullable last', () {
+      testInputs(
+        (
+          validInputs: [
+            ...baseValidInputs,
+            (input: null, expected: null),
+          ],
+          invalidInputs: baseInvalidInputs,
+        ),
+        ZArray(ZInt()).min(min).nullable(),
+      );
+    });
+  });
+
+  group('max', () {
+    const max = 3;
+    const baseValidInputs = <ValidInput>[
+      (input: <int>[], expected: <int>[]),
+      (input: [1], expected: [1]),
+      (input: [1, 2], expected: [1, 2]),
+      (input: [1, 2, 3], expected: [1, 2, 3]),
+    ];
+    const baseInvalidInputs = <InvalidInput>[
+      (input: [1, 2, 3, 4], expected: [ZIssueMaxLengthExceeded(maxLength: max, actualLength: 4)]),
+      (input: [1, 2, 3, 4, 5], expected: [ZIssueMaxLengthExceeded(maxLength: max, actualLength: 5)]),
+    ];
+
+    group('required', () {
+      testInputs(
+        (
+          validInputs: baseValidInputs,
+          invalidInputs: baseInvalidInputs,
+        ),
+        ZArray(ZInt()).max(max),
+      );
+    });
+    group('nullable first', () {
+      testInputs(
+        (
+          validInputs: [
+            ...baseValidInputs,
+            (input: null, expected: null),
+          ],
+          invalidInputs: baseInvalidInputs,
+        ),
+        ZArray(ZInt()).nullable().max(max),
+      );
+    });
+    group('nullable last', () {
+      testInputs(
+        (
+          validInputs: [
+            ...baseValidInputs,
+            (input: null, expected: null),
+          ],
+          invalidInputs: baseInvalidInputs,
+        ),
+        ZArray(ZInt()).max(max).nullable(),
+      );
+    });
+  });
+
   group('toArray', () {
     List<String> toUSD(List<double> vals) => vals.map((val) => '\$${val.toStringAsFixed(1)}').toList();
 


### PR DESCRIPTION
## 📌 Summary

Adds a way to simply limit number of items of a List.
## ✅ Changes

Add methods for ZArray and ZNullableArray:
- [ ] add `.max()`
- [ ] add `.min()`

## 📝 Changelog

Changelog updated:

- [ ] Yes
- [ ] No

## 🔍 Related Issues

<!-- Link to related issues, e.g. -->

Closes #59 

## 🧪 Testing

- [ ] Unit tests added/updated

<!-- Explain testing strategy if needed -->

> Example: Passed all unit tests.

## 🚨 Breaking Changes

- [ ] Yes
- [ ] No

If yes, describe:

## 📸 Screenshots / Videos (Optional)

None

<!-- Add before/after screenshots or videos if relevant -->

## 📓 Notes for Reviewers (Optional)

None

<!-- Any special instructions or things to look out for -->
