### PR TITLE
Feature/33 zstring regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [UNRELEASED]
 
+- add .regex() volidation for ZString
 - add .min() and .max() methods for ZArray
 - update build package to 3.0.2 and source_gen to 3.1.0
 

--- a/doc/types/types.md
+++ b/doc/types/types.md
@@ -98,6 +98,7 @@ classDiagram
 
         + min(min)
         + max(max)
+        + regex(r)
 
         + trim()
 
@@ -173,6 +174,7 @@ classDiagram
     class ZNullableString {
         + min(min)
         + max(max)
+        + regex(r)
 
         + trim()
 

--- a/lib/src/modifiers/rules.dart
+++ b/lib/src/modifiers/rules.dart
@@ -113,6 +113,18 @@ ResRule<T> maxNumRule<T extends num>(T max) {
   };
 }
 
+/// Returns a [ResRule] of type `ResRule<String>`, which checks the string value against [regex].
+///
+/// The returned rule will succeed if the input value `hasMatch` against the [regex] string,
+/// otherwise it will return a [ZIssueCustom].
+ResRule<String> regexRule(String regex, {String? message, String? code}) {
+  return (String val) {
+    return RegExp(regex).hasMatch(val)
+        ? ZRes.success(val)
+        : ZRes.errorSingleIssue(ZIssueCustom(message: message, code: code));
+  };
+}
+
 /// Returns a [ResRule] of type `ResRule<T>`, which wraps the passed refiner to return a [ZRes]
 /// depending on the refiner result.
 ///

--- a/lib/src/types/z_nullable_string.dart
+++ b/lib/src/types/z_nullable_string.dart
@@ -48,6 +48,17 @@ class ZNullableString extends ZBase<String?>
   ZNullableDateTime toDateTime() =>
       _transformBuildIn(constructor: ZNullableDateTime._withConfig, transformer: stringToDateTime);
 
+  /// Adds a rule to enforce that the string matches a regular expression string at [regex].
+  ///
+  /// Uses RegExp.hasMatch() internally.
+  ZNullableString regex(String regex, {String? message, String? code}) => _addRule(
+    regexRule(
+      regex,
+      message: message,
+      code: code,
+    ),
+  );
+
   /// Enable omitting this value. All rules will be skipped if the value is missing.
   ZNullableString optional() => _optional(constructor: ZNullableString._withConfig);
 

--- a/lib/src/types/z_string.dart
+++ b/lib/src/types/z_string.dart
@@ -60,6 +60,17 @@ class ZString extends ZBase<String> implements ZTransformations<String, String> 
   /// Enable omitting this value. All rules will be skipped if the value is missing.
   ZNullableString optional() => _optional(constructor: ZNullableString._withConfig);
 
+  /// Adds a rule to enforce that the string matches a regular expression string at [regex].
+  ///
+  /// Uses RegExp.hasMatch() internally.
+  ZString regex(String regex, {String? message, String? code}) => _addRule(
+    regexRule(
+      regex,
+      message: message,
+      code: code,
+    ),
+  );
+
   @override
   ZString refine(Refiner<String> refiner, {String? message, String? code}) => _refine(
     constructor: ZString._withConfig,

--- a/test/src/types/z_string_test.dart
+++ b/test/src/types/z_string_test.dart
@@ -161,6 +161,80 @@ void main() {
       );
     });
   });
+
+  group('regex', () {
+    const regex = 'Z[a-z]{2}A[a-z]{2}';
+    final baseValidInputs = <ValidInput>[
+      (input: 'I love ZodArt.', expected: 'I love ZodArt.'),
+      (input: 'ZodArt makes my life easier', expected: 'ZodArt makes my life easier'),
+    ];
+    const baseInvalidInputs = <InvalidInput>[
+      (input: 'I like Dart.', expected: [ZIssueCustom()]),
+      (input: 'I love zodart.', expected: [ZIssueCustom()]),
+    ];
+
+    group('required', () {
+      testInputs(
+        (
+          validInputs: baseValidInputs,
+          invalidInputs: baseInvalidInputs,
+        ),
+        ZString().regex(regex),
+      );
+    });
+    group('nullable first', () {
+      testInputs(
+        (
+          validInputs: [
+            ...baseValidInputs,
+            (input: null, expected: null),
+          ],
+          invalidInputs: baseInvalidInputs,
+        ),
+        ZString().nullable().regex(regex),
+      );
+    });
+    group('nullable last', () {
+      testInputs(
+        (
+          validInputs: [
+            ...baseValidInputs,
+            (input: null, expected: null),
+          ],
+          invalidInputs: baseInvalidInputs,
+        ),
+        ZString().regex(regex).nullable(),
+      );
+    });
+    group('custom errors', () {
+      final zStringWithCustomMessageAndCode = ZString().regex(regex, message: 'Custom error message', code: '01');
+      final validValidInputs = <ValidInput>[
+        (input: 'I love ZodArt.', expected: 'I love ZodArt.'),
+      ];
+      const invalidInputs = <InvalidInput>[
+        (input: 'I like Dart.', expected: [ZIssueCustom(message: 'Custom error message', code: '01')]),
+      ];
+      group('required', () {
+        testInputs(
+          (
+            validInputs: validValidInputs,
+            invalidInputs: invalidInputs,
+          ),
+          zStringWithCustomMessageAndCode,
+        );
+      });
+      group('nullable', () {
+        testInputs(
+          (
+            validInputs: validValidInputs,
+            invalidInputs: invalidInputs,
+          ),
+          zStringWithCustomMessageAndCode.nullable(),
+        );
+      });
+    });
+  });
+
   group('trim', () {
     final baseValidInputs = <ValidInput>[
       (input: '', expected: ''),


### PR DESCRIPTION
## 📌 Summary

Add and easy way for consumers to validate a String against regex allowing them to specify the output error.

## ✅ Changes

- [x] Add `.regex()` for ZString and ZNullableString

## 📝 Changelog

Changelog updated:

- [x] Yes
- [ ] No

## 🔍 Related Issues

<!-- Link to related issues, e.g. -->

Closes #33 

## 🧪 Testing

- [x] Unit tests added/updated

<!-- Explain testing strategy if needed -->

> Example: Passed all unit tests.

## 🚨 Breaking Changes

- [ ] Yes
- [x] No

If yes, describe:

## 📸 Screenshots / Videos (Optional)

None

<!-- Add before/after screenshots or videos if relevant -->

## 📓 Notes for Reviewers (Optional)

None

<!-- Any special instructions or things to look out for -->
