### PR TITLE
feat: getSummaryFor method does not include the path in message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [UNRELEASED]
 
+- getSummaryFor() does not include [path] in the response
 - add .regex() volidation for ZString
 - add .min() and .max() methods for ZArray
 - update build package to 3.0.2 and source_gen to 3.1.0

--- a/lib/src/base/z_res.dart
+++ b/lib/src/base/z_res.dart
@@ -155,7 +155,10 @@ extension ZResExt<T> on ZRes<T> {
 
   /// Returns localized issue messages joined by a newline for the given [path],
   /// or `null` if no matching issues are found.
-  String? getSummaryFor(String path) => _findIssuesForPath(path).map((issues) => issues.localizedSummary).toNullable();
+  ///
+  /// Includes the field path if [includePath] is set to true. Default: `false`.
+  String? getSummaryFor(String path, {bool includePath = false}) =>
+      _findIssuesForPath(path).map((issues) => issues.getLocalizedSummary(includePath: includePath)).toNullable();
 
   Option<ZIssues> _findIssuesForPath(String path) => match(
     (rawIssues) => findIssuesForPath(rawIssues, path),

--- a/lib/src/localization/localization_utils.dart
+++ b/lib/src/localization/localization_utils.dart
@@ -5,15 +5,28 @@ import 'localization.dart';
 ///
 /// Uses the [ZIssueLocalizationService] passed in [service] or [ZLocalizationContext.current] to resolve
 /// a human-readable message describing the issue.
-String localizeIssue(ZIssue issue, {ZIssueLocalizationService? service}) {
-  return (service ?? ZLocalizationContext.current).getIssueText(issue);
+///
+/// Includes the field path if [includePath] is set to true.
+String localizeIssue(ZIssue issue, {required bool includePath, ZIssueLocalizationService? service}) {
+  return (service ?? ZLocalizationContext.current).getIssueText(issue, includePath: includePath);
 }
 
 /// Extension on [ZIssues] (list of [ZIssue]) to provide localized messages easily.
 extension ZIssuesLocalizationExt on ZIssues {
   /// Returns a list of localized messages for all issues in this [ZIssues].
-  List<String> get localizedMessages => map(localizeIssue).toList();
+  List<String> get localizedMessages => getLocalizedMessages(includePath: true);
+
+  /// Returns a list of localized messages for all issues in this [ZIssues].
+  ///
+  /// Includes the field path if [includePath] is set to true.
+  List<String> getLocalizedMessages({required bool includePath}) =>
+      map((issue) => localizeIssue(issue, includePath: includePath)).toList();
 
   /// Returns all localized messages joined into a single string separated by newlines.
-  String get localizedSummary => localizedMessages.join('\n');
+  String get localizedSummary => getLocalizedSummary(includePath: true);
+
+  /// Returns all localized messages joined into a single string separated by newlines.
+  ///
+  /// Includes the field path if [includePath] is set to true.
+  String getLocalizedSummary({required bool includePath}) => getLocalizedMessages(includePath: includePath).join('\n');
 }

--- a/lib/src/localization/z_issue_localization_service.dart
+++ b/lib/src/localization/z_issue_localization_service.dart
@@ -23,8 +23,9 @@ class ZIssueLocalizationService {
   /// Returns a localized message for the given [ZIssue].
   ///
   /// Uses the appropriate method from [_zIssueLocalization] based on the type of the issue.
-  /// If the issue has an associated [ZIssue.path], it will be prefixed to the message.
-  String getIssueText(ZIssue issue) {
+  /// If the issue has an associated [ZIssue.path] and [includePath] is true,
+  /// the path will be prefixed to the message.
+  String getIssueText(ZIssue issue, {required bool includePath}) {
     final messageText = switch (issue) {
       final ZIssueLengthNotMet issue => _zIssueLocalization.lengthNotMet(issue),
       final ZIssueMinLengthNotMet issue => _zIssueLocalization.minLengthNotMet(issue),
@@ -40,7 +41,7 @@ class ZIssueLocalizationService {
 
     /// Prepends the issue path (if available) to the message text.
     final path = issue.path;
-    return path != null ? _withPath(messageText, path) : messageText;
+    return path != null && includePath ? _withPath(messageText, path) : messageText;
   }
 
   /// Prepends the issue path to the message text.

--- a/test/src/base/z_rest_test.dart
+++ b/test/src/base/z_rest_test.dart
@@ -72,13 +72,15 @@ void main() {
       late MockZIssueLocalizationService serviceMock;
       setUp(() {
         serviceMock = MockZIssueLocalizationService();
-        when(serviceMock.getIssueText(argThat(isA<ZIssue>()))).thenReturn(stubbedMessage);
+        when(
+          serviceMock.getIssueText(argThat(isA<ZIssue>()), includePath: anyNamed('includePath')),
+        ).thenReturn(stubbedMessage);
       });
 
       test('uses current ZIssueLocalizationService to return localized issueMessages', () {
         final res = runWithValue(zoneKeyForLocalizationService, serviceMock, () {
           expect(ZRes<String>.errorSingleIssue(testIssue).issueMessages, equals([stubbedMessage]));
-          verify(serviceMock.getIssueText(testIssue)).called(1);
+          verify(serviceMock.getIssueText(testIssue, includePath: true)).called(1);
           verifyNoMoreInteractions(serviceMock);
           return true;
         });
@@ -87,7 +89,7 @@ void main() {
       test('returns null for issueMessages on success and does not call getIssueText', () {
         final res = runWithValue(zoneKeyForLocalizationService, serviceMock, () {
           expect(ZRes.success('string value').issueMessages, isNull);
-          verifyNever(serviceMock.getIssueText(testIssue));
+          verifyNever(serviceMock.getIssueText(testIssue, includePath: anyNamed('includePath')));
           return true;
         });
         expect(res, isTrue);
@@ -107,15 +109,19 @@ void main() {
 
       setUp(() {
         serviceMock = MockZIssueLocalizationService();
-        when(serviceMock.getIssueText(testIssues[0])).thenReturn(stubbedMessages[0]);
-        when(serviceMock.getIssueText(testIssues[1])).thenReturn(stubbedMessages[1]);
+        when(
+          serviceMock.getIssueText(testIssues[0], includePath: anyNamed('includePath')),
+        ).thenReturn(stubbedMessages[0]);
+        when(
+          serviceMock.getIssueText(testIssues[1], includePath: anyNamed('includePath')),
+        ).thenReturn(stubbedMessages[1]);
       });
 
       test('uses current ZIssueLocalizationService to return localized issueSummary', () {
         final res = runWithValue(zoneKeyForLocalizationService, serviceMock, () {
           expect(ZRes<String>.error(testIssues).issueSummary, equals(stubbedMessages.join('\n')));
-          verify(serviceMock.getIssueText(testIssues[0])).called(1);
-          verify(serviceMock.getIssueText(testIssues[1])).called(1);
+          verify(serviceMock.getIssueText(testIssues[0], includePath: true)).called(1);
+          verify(serviceMock.getIssueText(testIssues[1], includePath: true)).called(1);
           verifyNoMoreInteractions(serviceMock);
           return true;
         });
@@ -124,7 +130,7 @@ void main() {
       test('returns null for issueSummary on success and does not call getIssueText', () {
         final res = runWithValue(zoneKeyForLocalizationService, serviceMock, () {
           expect(ZRes.success('string value').issueSummary, isNull);
-          verifyNever(serviceMock.getIssueText(any));
+          verifyNever(serviceMock.getIssueText(any, includePath: anyNamed('includePath')));
           return true;
         });
         expect(res, isTrue);
@@ -163,6 +169,13 @@ void main() {
           isA<String>(),
         );
       });
+      test('Path is not included in the return text', () {
+        final text = ZRes<String>.errorSingleIssue(
+          ZIssueMissingValue(rawPath: ZPath.property('zodArt')),
+        ).getSummaryFor('zodArt');
+
+        expect(RegExp(r'^\[.+\] .+$').hasMatch(text ?? ''), isFalse);
+      });
     });
     group('getRawIssuesFor', () {
       test('Returns null for success', () {
@@ -191,12 +204,14 @@ void main() {
       late MockZIssueLocalizationService serviceMock;
       setUp(() {
         serviceMock = MockZIssueLocalizationService();
-        when(serviceMock.getIssueText(argThat(isA<ZIssue>()))).thenReturn(stubbedMessage);
+        when(
+          serviceMock.getIssueText(argThat(isA<ZIssue>()), includePath: anyNamed('includePath')),
+        ).thenReturn(stubbedMessage);
       });
       test('uses current ZIssueLocalizationService to return localized messages', () {
         final res = runWithValue(zoneKeyForLocalizationService, serviceMock, () {
           expect(const ZError<String>([testIssue]).messages, equals([stubbedMessage]));
-          verify(serviceMock.getIssueText(testIssue)).called(1);
+          verify(serviceMock.getIssueText(testIssue, includePath: true)).called(1);
           verifyNoMoreInteractions(serviceMock);
           return true;
         });
@@ -217,15 +232,19 @@ void main() {
 
       setUp(() {
         serviceMock = MockZIssueLocalizationService();
-        when(serviceMock.getIssueText(testIssues[0])).thenReturn(stubbedMessages[0]);
-        when(serviceMock.getIssueText(testIssues[1])).thenReturn(stubbedMessages[1]);
+        when(
+          serviceMock.getIssueText(testIssues[0], includePath: anyNamed('includePath')),
+        ).thenReturn(stubbedMessages[0]);
+        when(
+          serviceMock.getIssueText(testIssues[1], includePath: anyNamed('includePath')),
+        ).thenReturn(stubbedMessages[1]);
       });
 
       test('uses current ZIssueLocalizationService to return localized summary', () {
         final res = runWithValue(zoneKeyForLocalizationService, serviceMock, () {
           expect(const ZError<String>(testIssues).summary, equals(stubbedMessages.join('\n')));
-          verify(serviceMock.getIssueText(testIssues[0])).called(1);
-          verify(serviceMock.getIssueText(testIssues[1])).called(1);
+          verify(serviceMock.getIssueText(testIssues[0], includePath: true)).called(1);
+          verify(serviceMock.getIssueText(testIssues[1], includePath: true)).called(1);
           verifyNoMoreInteractions(serviceMock);
           return true;
         });

--- a/test/src/base/z_rest_test.mocks.dart
+++ b/test/src/base/z_rest_test.mocks.dart
@@ -27,16 +27,28 @@ import 'package:zodart/src/localization/localization.dart' as _i2;
 /// See the documentation for Mockito's code generation for more information.
 class MockZIssueLocalizationService extends _i1.Mock implements _i2.ZIssueLocalizationService {
   @override
-  String getIssueText(_i3.ZIssue? issue) =>
+  String getIssueText(_i3.ZIssue? issue, {required bool? includePath}) =>
       (super.noSuchMethod(
-            Invocation.method(#getIssueText, [issue]),
+            Invocation.method(
+              #getIssueText,
+              [issue],
+              {#includePath: includePath},
+            ),
             returnValue: _i4.dummyValue<String>(
               this,
-              Invocation.method(#getIssueText, [issue]),
+              Invocation.method(
+                #getIssueText,
+                [issue],
+                {#includePath: includePath},
+              ),
             ),
             returnValueForMissingStub: _i4.dummyValue<String>(
               this,
-              Invocation.method(#getIssueText, [issue]),
+              Invocation.method(
+                #getIssueText,
+                [issue],
+                {#includePath: includePath},
+              ),
             ),
           )
           as String);

--- a/test/src/localization/localization_utils_test.dart
+++ b/test/src/localization/localization_utils_test.dart
@@ -16,14 +16,31 @@ void main() {
     late MockZIssueLocalizationService mockService;
     setUp(() {
       mockService = MockZIssueLocalizationService();
-      when(mockService.getIssueText(argThat(isA<ZIssue>()))).thenReturn(stubbedMessage);
+      when(
+        mockService.getIssueText(argThat(isA<ZIssue>()), includePath: anyNamed('includePath')),
+      ).thenReturn(stubbedMessage);
     });
     test('uses the passed ZIssueLocalizationService to localize the issue and returns the expected result', () {
       const issue = ZIssueLengthNotMet(expectedLength: 1, actualLength: 2);
-      final res = localizeIssue(issue, service: mockService);
+      final res = localizeIssue(issue, includePath: true, service: mockService);
       expect(res, stubbedMessage);
-      verify(mockService.getIssueText(issue)).called(1);
+      verify(mockService.getIssueText(issue, includePath: anyNamed('includePath'))).called(1);
       verifyNoMoreInteractions(mockService);
+    });
+    group('validates includePath param is properly passed', () {
+      const issue = ZIssueLengthNotMet(expectedLength: 1, actualLength: 2);
+      test('check includePath true', () {
+        final res = localizeIssue(issue, includePath: true, service: mockService);
+        expect(res, stubbedMessage);
+        verify(mockService.getIssueText(issue, includePath: true)).called(1);
+        verifyNoMoreInteractions(mockService);
+      });
+      test('check includePath false', () {
+        final res = localizeIssue(issue, includePath: false, service: mockService);
+        expect(res, stubbedMessage);
+        verify(mockService.getIssueText(issue, includePath: false)).called(1);
+        verifyNoMoreInteractions(mockService);
+      });
     });
   });
 }

--- a/test/src/localization/localization_utils_test.mocks.dart
+++ b/test/src/localization/localization_utils_test.mocks.dart
@@ -27,16 +27,28 @@ import 'package:zodart/src/localization/localization.dart' as _i2;
 /// See the documentation for Mockito's code generation for more information.
 class MockZIssueLocalizationService extends _i1.Mock implements _i2.ZIssueLocalizationService {
   @override
-  String getIssueText(_i3.ZIssue? issue) =>
+  String getIssueText(_i3.ZIssue? issue, {required bool? includePath}) =>
       (super.noSuchMethod(
-            Invocation.method(#getIssueText, [issue]),
+            Invocation.method(
+              #getIssueText,
+              [issue],
+              {#includePath: includePath},
+            ),
             returnValue: _i4.dummyValue<String>(
               this,
-              Invocation.method(#getIssueText, [issue]),
+              Invocation.method(
+                #getIssueText,
+                [issue],
+                {#includePath: includePath},
+              ),
             ),
             returnValueForMissingStub: _i4.dummyValue<String>(
               this,
-              Invocation.method(#getIssueText, [issue]),
+              Invocation.method(
+                #getIssueText,
+                [issue],
+                {#includePath: includePath},
+              ),
             ),
           )
           as String);

--- a/test/src/localization/z_issue_localization_service_test.dart
+++ b/test/src/localization/z_issue_localization_service_test.dart
@@ -27,54 +27,80 @@ void main() {
       when(mockIssueLocalization.missingValue(argThat(isA<ZIssueMissingValue>()))).thenReturn(stubbedMessage);
       when(mockIssueLocalization.custom(argThat(isA<ZIssueCustom>()))).thenReturn(stubbedMessage);
     });
+    group('Check that proper method is called based on ZIssueType', () {
+      test('calls lengthNotMet for ZIssueLengthNotMet', () {
+        const issue = ZIssueLengthNotMet(expectedLength: 1, actualLength: 2);
+        service.getIssueText(issue, includePath: true);
+        verify(mockIssueLocalization.lengthNotMet(issue)).called(1);
+        verifyNoMoreInteractions(mockIssueLocalization);
+      });
+      test('calls minLengthNotMet for ZIssueMinLengthNotMet', () {
+        const issue = ZIssueMinLengthNotMet(minLength: 10, actualLength: 9);
+        service.getIssueText(issue, includePath: true);
+        verify(mockIssueLocalization.minLengthNotMet(issue)).called(1);
+        verifyNoMoreInteractions(mockIssueLocalization);
+      });
+      test('calls maxLengthExceeded for ZIssueMaxLengthExceeded', () {
+        const issue = ZIssueMaxLengthExceeded(maxLength: 10, actualLength: 11);
+        service.getIssueText(issue, includePath: true);
+        verify(mockIssueLocalization.maxLengthExceeded(issue)).called(1);
+        verifyNoMoreInteractions(mockIssueLocalization);
+      });
+      test('calls minNotMet for ZIssueMinNotMet', () {
+        const issue = ZIssueMinNotMet(min: 10, val: 9);
+        service.getIssueText(issue, includePath: true);
+        verify(mockIssueLocalization.minNotMet(issue)).called(1);
+        verifyNoMoreInteractions(mockIssueLocalization);
+      });
+      test('calls maxExceeded for ZIssueMaxExceeded', () {
+        const issue = ZIssueMaxExceeded(max: 10, val: 11);
+        service.getIssueText(issue, includePath: true);
+        verify(mockIssueLocalization.maxExceeded(issue)).called(1);
+        verifyNoMoreInteractions(mockIssueLocalization);
+      });
+      test('calls parseFail for ZIssueParseFail', () {
+        const issue = ZIssueParseFail(from: String, to: int, val: 'dummy');
+        service.getIssueText(issue, includePath: true);
+        verify(mockIssueLocalization.parseFail(issue)).called(1);
+        verifyNoMoreInteractions(mockIssueLocalization);
+      });
+      test('calls missingValue for ZIssueMissingValue', () {
+        final issue = ZIssueMissingValue(rawPath: ZPath.property('name'));
+        service.getIssueText(issue, includePath: true);
+        verify(mockIssueLocalization.missingValue(issue)).called(1);
+        verifyNoMoreInteractions(mockIssueLocalization);
+      });
+      test('calls custom for ZIssuCustom', () {
+        const issue = ZIssueCustom();
+        service.getIssueText(issue, includePath: true);
+        verify(mockIssueLocalization.custom(issue)).called(1);
+        verifyNoMoreInteractions(mockIssueLocalization);
+      });
+    });
 
-    test('calls lengthNotMet for ZIssueLengthNotMet', () {
-      const issue = ZIssueLengthNotMet(expectedLength: 1, actualLength: 2);
-      service.getIssueText(issue);
-      verify(mockIssueLocalization.lengthNotMet(issue)).called(1);
-      verifyNoMoreInteractions(mockIssueLocalization);
-    });
-    test('calls minLengthNotMet for ZIssueMinLengthNotMet', () {
-      const issue = ZIssueMinLengthNotMet(minLength: 10, actualLength: 9);
-      service.getIssueText(issue);
-      verify(mockIssueLocalization.minLengthNotMet(issue)).called(1);
-      verifyNoMoreInteractions(mockIssueLocalization);
-    });
-    test('calls maxLengthExceeded for ZIssueMaxLengthExceeded', () {
-      const issue = ZIssueMaxLengthExceeded(maxLength: 10, actualLength: 11);
-      service.getIssueText(issue);
-      verify(mockIssueLocalization.maxLengthExceeded(issue)).called(1);
-      verifyNoMoreInteractions(mockIssueLocalization);
-    });
-    test('calls minNotMet for ZIssueMinNotMet', () {
-      const issue = ZIssueMinNotMet(min: 10, val: 9);
-      service.getIssueText(issue);
-      verify(mockIssueLocalization.minNotMet(issue)).called(1);
-      verifyNoMoreInteractions(mockIssueLocalization);
-    });
-    test('calls maxExceeded for ZIssueMaxExceeded', () {
-      const issue = ZIssueMaxExceeded(max: 10, val: 11);
-      service.getIssueText(issue);
-      verify(mockIssueLocalization.maxExceeded(issue)).called(1);
-      verifyNoMoreInteractions(mockIssueLocalization);
-    });
-    test('calls parseFail for ZIssueParseFail', () {
-      const issue = ZIssueParseFail(from: String, to: int, val: 'dummy');
-      service.getIssueText(issue);
-      verify(mockIssueLocalization.parseFail(issue)).called(1);
-      verifyNoMoreInteractions(mockIssueLocalization);
-    });
-    test('calls missingValue for ZIssueMissingValue', () {
-      final issue = ZIssueMissingValue(rawPath: ZPath.property('name'));
-      service.getIssueText(issue);
-      verify(mockIssueLocalization.missingValue(issue)).called(1);
-      verifyNoMoreInteractions(mockIssueLocalization);
-    });
-    test('calls custom for ZIssuCustom', () {
-      const issue = ZIssueCustom();
-      service.getIssueText(issue);
-      verify(mockIssueLocalization.custom(issue)).called(1);
-      verifyNoMoreInteractions(mockIssueLocalization);
+    group('test path is properly prepended to the message based on includePath parameter', () {
+      group('path is empty', () {
+        final issue = ZIssueCustom(rawPath: ZPath.empty());
+        test('does not prepend path when empty and includePath = true', () {
+          final text = service.getIssueText(issue, includePath: true);
+          expect(text, stubbedMessage);
+        });
+        test('does not prepend path when empty and includePath = false', () {
+          final text = service.getIssueText(issue, includePath: false);
+          expect(text, stubbedMessage);
+        });
+      });
+      group('path is not empty', () {
+        final issue = ZIssueCustom(rawPath: ZPath.property('testPath'));
+        test('prepends path when not empty and includePath = true', () {
+          final text = service.getIssueText(issue, includePath: true);
+          expect(text, '[testPath] $stubbedMessage');
+        });
+        test('does not prepends path when not empty and includePath = false', () {
+          final text = service.getIssueText(issue, includePath: false);
+          expect(text, stubbedMessage);
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
## 📌 Summary

As consumer using .getSummaryFor(path) I want it to exclude the [path] from the returning message so I can use it as is in Forms.

## ✅ Changes

- [x] getSummaryFor does not include the path in the error message
- [x] add additional tests for path prepending in existing methods

## 📝 Changelog

Changelog updated:

- [x] Yes
- [ ] No

## 🔍 Related Issues

<!-- Link to related issues, e.g. -->

Closes #82

## 🧪 Testing

- [x] Unit tests added/updated

<!-- Explain testing strategy if needed -->

> Example: Passed all unit tests.

## 🚨 Breaking Changes

- [ ] Yes
- [x] No

If yes, describe:

## 📸 Screenshots / Videos (Optional)

None

<!-- Add before/after screenshots or videos if relevant -->

## 📓 Notes for Reviewers (Optional)

None

<!-- Any special instructions or things to look out for -->
