### PR TITLE
Feature/3, 38 to upper lower case for ZString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+- Add .toUpperCase() for ZString
+- Add .toLowerCase() for ZString
+
 ## 1.1.0 - 2025-09-04
 
 - Add support for Records as output type in code generation

--- a/doc/types/types.md
+++ b/doc/types/types.md
@@ -101,6 +101,8 @@ classDiagram
         + regex(r)
 
         + trim()
+        + toLowerCase()
+        + toUpperCase()
 
         + refine(refiner, message?, code?)
         + superRefine(refiner)
@@ -177,6 +179,8 @@ classDiagram
         + regex(r)
 
         + trim()
+        + toLowerCase()
+        + toUpperCase()
 
         + refine(refiner, message?, code?)
         + superRefine(refiner)

--- a/lib/src/types/z_nullable_string.dart
+++ b/lib/src/types/z_nullable_string.dart
@@ -37,6 +37,20 @@ class ZNullableString extends ZBase<String?>
     isUserDefined: false,
   );
 
+  /// Adds a rule which converts the value to lower case.
+  ZNullableString toLowerCase() => _processPure<ZNullableString, String>(
+    constructor: ZNullableString._withConfig,
+    processor: (val) => val.toLowerCase(),
+    isUserDefined: false,
+  );
+
+  /// Adds a rule which converts the value to upper case.
+  ZNullableString toUpperCase() => _processPure<ZNullableString, String>(
+    constructor: ZNullableString._withConfig,
+    processor: (val) => val.toUpperCase(),
+    isUserDefined: false,
+  );
+
   /// Adds a transformation of current nullable [String] value to nullable [int].
   ZNullableInt toInt() => _transformBuildIn(constructor: ZNullableInt._withConfig, transformer: stringToInt);
 

--- a/lib/src/types/z_string.dart
+++ b/lib/src/types/z_string.dart
@@ -39,6 +39,20 @@ class ZString extends ZBase<String> implements ZTransformations<String, String> 
     isUserDefined: false,
   );
 
+  /// Adds a rule which converts the value to lower case.
+  ZString toLowerCase() => _processPure<ZString, String>(
+    constructor: ZString._withConfig,
+    processor: (val) => val.toLowerCase(),
+    isUserDefined: false,
+  );
+
+  /// Adds a rule which converts the value to upper case.
+  ZString toUpperCase() => _processPure<ZString, String>(
+    constructor: ZString._withConfig,
+    processor: (val) => val.toUpperCase(),
+    isUserDefined: false,
+  );
+
   /// Adds a transformation of current [String] value to [int].
   ZInt toInt() => _transformBuildIn(constructor: ZInt._withConfig, transformer: stringToInt);
 

--- a/test/src/types/z_string_test.dart
+++ b/test/src/types/z_string_test.dart
@@ -278,6 +278,88 @@ void main() {
       );
     });
   });
+  group('toLowerCase', () {
+    final baseValidInputs = <ValidInput>[
+      (input: '', expected: ''),
+      (input: 'lower Case', expected: 'lower case'),
+      (input: ' LOWER_CASE', expected: ' lower_case'),
+    ];
+
+    group('required', () {
+      testInputs(
+        (
+          validInputs: baseValidInputs,
+          invalidInputs: [],
+        ),
+        ZString().toLowerCase(),
+      );
+    });
+    group('nullable first', () {
+      testInputs(
+        (
+          validInputs: [
+            ...baseValidInputs,
+            (input: null, expected: null),
+          ],
+          invalidInputs: [],
+        ),
+        ZString().nullable().toLowerCase(),
+      );
+    });
+    group('nullable last', () {
+      testInputs(
+        (
+          validInputs: [
+            ...baseValidInputs,
+            (input: null, expected: null),
+          ],
+          invalidInputs: [],
+        ),
+        ZString().toLowerCase().nullable(),
+      );
+    });
+  });
+  group('toUpperCase', () {
+    final baseValidInputs = <ValidInput>[
+      (input: '', expected: ''),
+      (input: 'upPer Case', expected: 'UPPER CASE'),
+      (input: ' upper_case', expected: ' UPPER_CASE'),
+    ];
+
+    group('required', () {
+      testInputs(
+        (
+          validInputs: baseValidInputs,
+          invalidInputs: [],
+        ),
+        ZString().toUpperCase(),
+      );
+    });
+    group('nullable first', () {
+      testInputs(
+        (
+          validInputs: [
+            ...baseValidInputs,
+            (input: null, expected: null),
+          ],
+          invalidInputs: [],
+        ),
+        ZString().nullable().toUpperCase(),
+      );
+    });
+    group('nullable last', () {
+      testInputs(
+        (
+          validInputs: [
+            ...baseValidInputs,
+            (input: null, expected: null),
+          ],
+          invalidInputs: [],
+        ),
+        ZString().toUpperCase().nullable(),
+      );
+    });
+  });
   group('toInt', () {
     final baseValidInputs = <ValidInput>[
       (input: '-1', expected: -1),


### PR DESCRIPTION
## 📌 Summary

Allow consumers to easily transform strings to upper/lower case.

## ✅ Changes

- [ ] add `.toUpperCase()` for ZString
- [ ] add `.toLowerCase()` for ZString

## 📝 Changelog

Changelog updated:

- [ ] Yes
- [ ] No

## 🔍 Related Issues

<!-- Link to related issues, e.g. -->

Closes #37 
Closes #38 

## 🧪 Testing

- [ ] Unit tests added/updated

<!-- Explain testing strategy if needed -->

> Example: Passed all unit tests.

## 🚨 Breaking Changes

- [ ] Yes
- [ ] No

If yes, describe:

## 📸 Screenshots / Videos (Optional)

None

<!-- Add before/after screenshots or videos if relevant -->

## 📓 Notes for Reviewers (Optional)

None

<!-- Any special instructions or things to look out for -->
