### PR TITLE
Feature/101 cross field validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## [UNRELEASED]
+## 1.4.0 - UNRELEASED
 
+- Add cross-field validation for ZObject
 - Turn off linter and test coverage for generated files
 
 ## 1.3.0 - 2025-11-25

--- a/lib/src/base/base.dart
+++ b/lib/src/base/base.dart
@@ -3,4 +3,4 @@ export 'z_path.dart';
 export 'z_res.dart';
 export 'z_transform.dart';
 export 'z_typedefs.dart';
-export 'zodart_internal_exception.dart';
+export 'zodart_exceptions.dart';

--- a/lib/src/base/base.dart
+++ b/lib/src/base/base.dart
@@ -1,3 +1,4 @@
+export 'cross_field_validation.dart' show CrossFieldValidator, ParsedFieldAccessor, ParsedFieldAccessorFactory;
 export 'z_issue.dart';
 export 'z_path.dart';
 export 'z_res.dart';

--- a/lib/src/base/cross_field_validation.dart
+++ b/lib/src/base/cross_field_validation.dart
@@ -1,0 +1,130 @@
+import 'package:meta/meta.dart';
+
+import 'z_issue.dart';
+import 'z_typedefs.dart';
+import 'zodart_exceptions.dart';
+
+// ! To ensure type-safety while avoid poluting ZObject with generics needed for the cross-field validation
+// ! proper types are ensured on all public apis, but kept unsafe(dynamic) in the internal representation.
+
+/// Cross-field validator function type.
+///
+/// Returns `null` on validation success,
+/// or a [SuperRefinerErrorRes] on validation failure.
+typedef CrossFieldValidator<G extends ParsedFieldAccessor> = SuperRefinerErrorRes? Function(G fieldValues);
+
+/// Factory function type for creating [ParsedFieldAccessor] instances.
+///
+/// Used to construct concrete (child) implementations of
+/// [ParsedFieldAccessor] from a schema and parsed field values.
+typedef ParsedFieldAccessorFactory<G extends ParsedFieldAccessor> =
+    G Function(ObjectSchema schema, Map<String, dynamic> parsedValues);
+
+/// Exception thrown when the field value is not ready
+///
+/// This exception is used to skip an execution of [CrossFieldValidator],
+/// when a field value used in the validation is not ready (i.e. parse result is not success)
+@internal
+class ParsedFieldValueNotReadyException implements Exception {}
+
+/// Exception thrown at [ParsedFieldAccessor] when consumer is trying to access a field,
+/// which is not defined in the schema.
+class FieldNotInSchemaAccessorException implements ZConsumerCausedException {
+  /// Default constructor to create the instance.
+  const FieldNotInSchemaAccessorException({required this.fieldName, required this.schemaFieldNames});
+
+  /// Name of the field which is not in the schema.
+  final String fieldName;
+
+  /// List of all field names in the schema.
+  final List<String> schemaFieldNames;
+
+  @override
+  String toString() =>
+      'FieldNotInSchemaAccessorException: Field "$fieldName" is not defined in the schema. '
+      'Available fields are: $schemaFieldNames.';
+}
+
+/// Internal unsafe representation of `ParsedFieldAccessorFactory`.
+@internal
+typedef UnsafeParsedFieldAccessorFactory = dynamic Function(ObjectSchema schema, Map<String, dynamic> parsedValues);
+
+/// Internal unsafe representation of `CrossFieldValidator`'s list.
+@internal
+typedef UnsafeCrossFieldValidators = List<dynamic>;
+
+/// Internal unsafe record type that groups the dependencies required for
+/// cross-field validation.
+@internal
+typedef UnsafeCrossFieldValidation = ({
+  UnsafeCrossFieldValidators crossValidators,
+  UnsafeParsedFieldAccessorFactory parsedFieldAccessorFactory,
+});
+
+/// Class used to access parse result of fields during `ZObject` parsing before the object is created.
+class ParsedFieldAccessor {
+  /// Default ctor to construct the instance.
+  ParsedFieldAccessor(ObjectSchema schema, Map<String, dynamic> parsedValues)
+    : _parsedValues = Map.unmodifiable(parsedValues),
+      _schema = Map.unmodifiable(schema);
+
+  final Map<String, dynamic> _parsedValues;
+  final ObjectSchema _schema;
+
+  /// Operator to access a parsed field value in dev-friendly manner, `e.g. values['firstName']`
+  ///
+  /// - Throws [FieldNotInSchemaAccessorException] if the field is NOT defined in the schema.
+  /// - Throws [ParsedFieldValueNotReadyException] if the field is NOT included in `parsedValues`.
+  /// - Returns the parsed field value otherwise.
+  dynamic operator [](String fieldName) {
+    if (!_schema.containsKey(fieldName)) {
+      throw FieldNotInSchemaAccessorException(fieldName: fieldName, schemaFieldNames: List.unmodifiable(_schema.keys));
+    }
+
+    if (!_parsedValues.containsKey(fieldName)) {
+      throw ParsedFieldValueNotReadyException();
+    }
+
+    return _parsedValues[fieldName];
+  }
+}
+
+/// A factory to construct an instace of [CrossFieldValidationExecutor].
+typedef CrossFieldValidationExecutorFactory =
+    CrossFieldValidationExecutor Function(UnsafeCrossFieldValidation crossFieldValidation);
+
+/// A helper class to execute the [UnsafeCrossFieldValidation] and collect results.
+class CrossFieldValidationExecutor {
+  /// Default constructor to create the instance.
+  const CrossFieldValidationExecutor(UnsafeCrossFieldValidation crossValidation) : _crossValidation = crossValidation;
+
+  final UnsafeCrossFieldValidation _crossValidation;
+
+  /// Execute all validators defined at [_crossValidation] and returns a list of [ZIssue]s for validation failures.
+  ///
+  /// Validators which try to access a field which doesn't have a parsed value ready
+  /// (i.e. parse result is not success), are skipped.
+  List<ZIssue> execute({
+    required Map<String, dynamic> succesfullyParsedValues,
+    required ObjectSchema schema,
+  }) {
+    final (:crossValidators, :parsedFieldAccessorFactory) = _crossValidation;
+    final parsedValueAccessor = parsedFieldAccessorFactory(schema, succesfullyParsedValues);
+
+    final zIssues = <ZIssue>[];
+    for (final crossValidator in crossValidators) {
+      try {
+        // Needed as the internal representation is kept unsafe on purpose.
+        // ignore: avoid_dynamic_calls
+        final validatorResult = crossValidator(parsedValueAccessor) as SuperRefinerErrorRes?;
+        if (validatorResult != null) {
+          zIssues.addAll([validatorResult.$1, ...validatorResult.others]);
+        }
+      } on ParsedFieldValueNotReadyException catch (_) {
+        continue;
+      }
+    }
+
+    return zIssues;
+  }
+}

--- a/lib/src/base/zodart_exceptions.dart
+++ b/lib/src/base/zodart_exceptions.dart
@@ -33,3 +33,8 @@ class ZodArtInternalException implements Exception {
     return msg;
   }
 }
+
+/// Generic exception for exceptions caused by consumer (i.e. user) input
+///
+/// Used to distinguish between library internal exceptions and user caused ones
+abstract class ZConsumerCausedException implements Exception {}

--- a/lib/src/code_generation/schema_parsing/zodart_annotation.dart
+++ b/lib/src/code_generation/schema_parsing/zodart_annotation.dart
@@ -2,7 +2,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
-import '../../base/zodart_internal_exception.dart';
+import '../../base/zodart_exceptions.dart';
 import '../annotations.dart';
 
 part 'zodart_annotation.freezed.dart';

--- a/lib/src/modifiers/parsers.dart
+++ b/lib/src/modifiers/parsers.dart
@@ -1,4 +1,5 @@
 import '../base/base.dart';
+import '../base/cross_field_validation.dart';
 import '../types/types.dart';
 
 /// Strictly parses [val] as type [T].
@@ -51,15 +52,26 @@ ZRes<double> parseDouble(Object? val) => parseStrict(val);
 /// Returns success if [val] is a [bool], otherwise an error.
 ZRes<bool> parseBool(Object? val) => parseStrict(val);
 
-/// Returns a parser function that parses an object of type [T] using the given [schema]
+/// Returns a parser function that parses an object of type [T] using the given [schema],
+/// applies [crossFieldValidation] using the [crossFieldValidationExecutor]
 /// and maps the parsed map to [T] using the provided [mapper].
 ///
 /// The returned function expects an [Object?] and attempts to parse it as a [Map<String, dynamic>].
 /// If successful, it delegates to [parseObjectFromMap].
 /// Otherwise, returns a single parse failure error.
-ZRes<T> Function(Object?) parseObject<T>(ObjectSchema schema, ObjectMapper<T> mapper) => (Object? val) {
+ZRes<T> Function(Object?) parseObject<T>({
+  required ObjectSchema schema,
+  required ObjectMapper<T> mapper,
+  required UnsafeCrossFieldValidation crossFieldValidation,
+  CrossFieldValidationExecutorFactory crossFieldValidationExecutor = CrossFieldValidationExecutor.new,
+}) => (Object? val) {
   return switch (val) {
-    final Map<String, dynamic> val => parseObjectFromMap(mapper: mapper, schema: schema, val: val),
+    final Map<String, dynamic> val => parseObjectFromMap(
+      mapper: mapper,
+      schema: schema,
+      val: val,
+      crossFieldValidationExecutor: crossFieldValidationExecutor(crossFieldValidation),
+    ),
     _ => ZRes.errorSingleIssue(ZIssueParseFail(from: val.runtimeType, to: T, val: val)),
   };
 };
@@ -70,12 +82,15 @@ ZRes<T> Function(Object?) parseObject<T>(ObjectSchema schema, ObjectMapper<T> ma
 /// Iterates over each entry in the [schema], parses the corresponding value from [val],
 /// and collects parsing issues with prepended paths.
 ///
+/// Then runs the [crossFieldValidationExecutor] and collects all issues.
+///
 /// Returns a success with the mapped object if no issue occurs,
 /// otherwise returns an error containing all collected issues.
 ZRes<T> parseObjectFromMap<T>({
   required ObjectSchema schema,
   required ObjectMapper<T> mapper,
   required Map<String, dynamic> val,
+  required CrossFieldValidationExecutor crossFieldValidationExecutor,
 }) {
   final parsedValuesPerKey = <String, dynamic>{};
   final issuesForAllKeys = <ZIssue>[];
@@ -98,6 +113,13 @@ ZRes<T> parseObjectFromMap<T>({
           (val) => parsedValuesPerKey[key] = val,
         );
   }
+
+  final crossValidationIssues = crossFieldValidationExecutor.execute(
+    succesfullyParsedValues: parsedValuesPerKey,
+    schema: schema,
+  );
+
+  issuesForAllKeys.addAll(crossValidationIssues);
 
   return issuesForAllKeys.isEmpty ? ZRes.success(mapper(parsedValuesPerKey)) : ZRes.error(issuesForAllKeys);
 }

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import '../base/base.dart';
+import '../base/cross_field_validation.dart';
 import '../internal_operation_interfaces.dart';
 import '../modifiers/modifiers.dart';
 import '../z_base_config/z_base_config.dart';

--- a/lib/src/types/z_base.dart
+++ b/lib/src/types/z_base.dart
@@ -209,6 +209,9 @@ sealed class ZBase<T> {
 
       // NOTE: Need to fix the generic type for Left as it is untouched during processing above
       return _fixLeftGenericType(parseRes);
+    } on ZConsumerCausedException catch (_) {
+      // All consumer caused exceptions will be propageted without any change
+      rethrow;
     } on ZodArtInternalException catch (e, stack) {
       /// NOTE: Add ZBaseConfig to the exception and throw
       throw ZodArtInternalException(

--- a/lib/src/types/z_object.dart
+++ b/lib/src/types/z_object.dart
@@ -19,17 +19,66 @@ part of 'types.dart';
 // final person = personSchema.parse({'firstName': 'Zod', 'lastName': 'Art'});
 /// ```
 class ZObject<T extends Object> extends ZBase<T> implements ZTransformations<T, T> {
-  /// Factory constructor that creates a new instance using the given [schema]
-  /// for parsing and the [fromJson] function for mapping parsed data to type [T].
-  factory ZObject.withMapper(ZSchema schema, {required ObjectMapper<T> fromJson}) => ZObject._new(schema, fromJson);
+  /// Factory constructor that creates a [ZObject] using the given [schema]
+  /// for parsing and the [fromJson] function to map parsed data to type [T].
+  ///
+  /// Cross-field validators, if provided, operates on the default
+  /// [ParsedFieldAccessor].
+  factory ZObject.withMapper(
+    ZSchema schema, {
+    required ObjectMapper<T> fromJson,
+    List<CrossFieldValidator<ParsedFieldAccessor>> crossValidators = const [],
+  }) => ZObject._new(
+    schema: schema,
+    mapper: fromJson,
+    crossFieldValidation: (
+      parsedFieldAccessorFactory: ParsedFieldAccessor.new,
+      crossValidators: crossValidators,
+    ),
+  );
 
-  ZObject._new(ZSchema schema, ObjectMapper<T> mapper) : super._new(Parsing.buildIn(parseObject<T>(schema, mapper)));
+  ZObject._new({
+    required ZSchema schema,
+    required ObjectMapper<T> mapper,
+    required UnsafeCrossFieldValidation crossFieldValidation,
+  }) : super._new(
+         Parsing.buildIn(
+           parseObject<T>(
+             schema: schema,
+             mapper: mapper,
+             crossFieldValidation: crossFieldValidation,
+           ),
+         ),
+       );
 
   /// Internal constructor that accepts a custom configuration.
   ///
   /// Typically used for creating modified versions of this validator,
   /// such as after applying transformation or additional rules.
   ZObject._withConfig(super.config) : super._withConfig();
+
+  /// Creates a [ZObject] with strongly typed cross-field validation.
+  ///
+  /// The returned instance uses the provided [schema] for parsing and
+  /// [fromJson] to map parsed data to type [T].
+  ///
+  /// The generic type [G] enforces type safety for cross-field validation by
+  /// ensuring that [crossValidators] operate on a concrete
+  /// [ParsedFieldAccessor] implementation created by
+  /// [parsedFieldAccessorFactory].
+  static ZObject<T> withTypedCrossFieldValidation<T extends Object, G extends ParsedFieldAccessor>(
+    ZSchema schema, {
+    required ObjectMapper<T> fromJson,
+    required List<CrossFieldValidator<G>> crossValidators,
+    required ParsedFieldAccessorFactory<G> parsedFieldAccessorFactory,
+  }) => ZObject._new(
+    schema: schema,
+    mapper: fromJson,
+    crossFieldValidation: (
+      parsedFieldAccessorFactory: parsedFieldAccessorFactory,
+      crossValidators: crossValidators,
+    ),
+  );
 
   /// Enable `null` value. All rules will be skipped for null values.
   ZNullableObject<T> nullable() => _nullable(constructor: ZNullableObject<T>._withConfig);

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -1,6 +1,6 @@
 import 'package:fpdart/fpdart.dart';
 
-import '../base/zodart_internal_exception.dart';
+import '../base/zodart_exceptions.dart';
 import '../zodart_base.dart';
 
 /// Extension which adds `whereOrNull` to [Iterable]

--- a/lib/src/zodart_base.dart
+++ b/lib/src/zodart_base.dart
@@ -1,4 +1,4 @@
-export 'base/base.dart' hide ZodArtInternalException;
+export 'base/base.dart' hide ZConsumerCausedException, ZodArtInternalException;
 export 'code_generation/code_generation.dart';
 export 'localization/localization.dart'
     show Language, ZIssueLocalizationService, ZIssuesLocalizationExt, ZLocalizationContext;

--- a/test/src/base/cross_field_validation_test.dart
+++ b/test/src/base/cross_field_validation_test.dart
@@ -1,0 +1,181 @@
+import 'package:test/test.dart';
+import 'package:zodart/src/base/base.dart';
+import 'package:zodart/src/base/cross_field_validation.dart';
+import 'package:zodart/src/types/types.dart';
+
+void main() {
+  group('ParsedFieldAccessor', () {
+    late final ParsedFieldAccessor parsedFieldAccessor;
+
+    setUpAll(() {
+      parsedFieldAccessor = ParsedFieldAccessor(
+        {
+          'id': ZInt(),
+          'name': ZString(),
+        },
+        {
+          'name': 'ZodArt',
+        },
+      );
+    });
+
+    test('Returns the correct value for successfuly parsed value.', () {
+      expect(parsedFieldAccessor['name'], 'ZodArt');
+    });
+
+    test('Throws a ParsedFieldValueNotReadyException when the field is not present in the parsedValues.', () {
+      expect(() => parsedFieldAccessor['id'], throwsA(isA<ParsedFieldValueNotReadyException>()));
+    });
+
+    test('Throws a FieldNotInSchemaAccessorException when the field is not in the schema.', () {
+      expect(
+        () => parsedFieldAccessor['dummy'],
+        throwsA(
+          isA<FieldNotInSchemaAccessorException>()
+              .having(
+                (e) => e.fieldName,
+                'fieldName',
+                'dummy',
+              )
+              .having(
+                (e) => e.schemaFieldNames,
+                'schemaFieldNames',
+                ['id', 'name'],
+              ),
+        ),
+      );
+    });
+  });
+
+  group('FieldNotInSchemaAccessorException', () {
+    test('toString returns correct string representation', () {
+      final toStringRes = const FieldNotInSchemaAccessorException(
+        fieldName: 'email',
+        schemaFieldNames: ['id', 'name'],
+      ).toString();
+
+      expect(
+        toStringRes,
+        'FieldNotInSchemaAccessorException: Field "email" is not defined in the schema. '
+        'Available fields are: [id, name].',
+      );
+    });
+  });
+
+  group('CrossFieldValidationExecutor', () {
+    const zIssues1 = ZIssue.custom(message: 'issue1');
+    const zIssues2 = ZIssue.custom(message: 'issue2');
+    const zIssues3 = ZIssue.custom(message: 'issue3');
+
+    test('Return empty list when no validator is passed', () {
+      final validation = (
+        crossValidators: <dynamic>[],
+        parsedFieldAccessorFactory: ParsedFieldAccessor.new,
+      );
+
+      final res = CrossFieldValidationExecutor(validation).execute(
+        succesfullyParsedValues: {},
+        schema: {},
+      );
+
+      expect(res, isEmpty);
+    });
+
+    test('Return empty list when the only validator returns null', () {
+      final validators = [(_) => null];
+
+      final validation = (
+        crossValidators: validators,
+        parsedFieldAccessorFactory: ParsedFieldAccessor.new,
+      );
+
+      final res = CrossFieldValidationExecutor(validation).execute(
+        succesfullyParsedValues: {},
+        schema: {},
+      );
+
+      expect(res, isEmpty);
+    });
+
+    test('Return the issue returned by the validator', () {
+      final validators = <CrossFieldValidator>[(_) => (zIssues1, others: [])];
+
+      final validation = (
+        crossValidators: validators,
+        parsedFieldAccessorFactory: ParsedFieldAccessor.new,
+      );
+
+      final res = CrossFieldValidationExecutor(validation).execute(
+        succesfullyParsedValues: {},
+        schema: {},
+      );
+
+      expect(res, equals([zIssues1]));
+    });
+
+    test('Return all issues returned by the validators', () {
+      final validators = <CrossFieldValidator>[
+        (_) => (zIssues1, others: [zIssues2]),
+        (_) => null,
+        (_) => (zIssues3, others: []),
+      ];
+
+      final validation = (
+        crossValidators: validators,
+        parsedFieldAccessorFactory: ParsedFieldAccessor.new,
+      );
+
+      final res = CrossFieldValidationExecutor(validation).execute(
+        succesfullyParsedValues: {},
+        schema: {},
+      );
+
+      expect(res, equals([zIssues1, zIssues2, zIssues3]));
+    });
+
+    test('Validators accessing value which is not in succesfullyParsedValues are skipped', () {
+      final validators = <CrossFieldValidator>[
+        (_) => (zIssues1, others: []),
+        (accessor) => accessor['name'] == '' ? null : (zIssues2, others: []),
+        (accessor) => accessor['id'] == 0 ? null : (zIssues3, others: []),
+      ];
+
+      final validation = (
+        crossValidators: validators,
+        parsedFieldAccessorFactory: ParsedFieldAccessor.new,
+      );
+
+      final res = CrossFieldValidationExecutor(validation).execute(
+        succesfullyParsedValues: {
+          'id': 1,
+        },
+        schema: {
+          'id': ZInt(),
+          'name': ZString(),
+        },
+      );
+
+      expect(res, equals([zIssues1, zIssues3]));
+    });
+
+    test('Throws FieldNotInSchemaAccessorException when validator tries to access a field not in the schema', () {
+      final validators = <CrossFieldValidator>[
+        (_) => (zIssues1, others: []),
+        (accessor) => accessor['dummy'] == '' ? null : (zIssues2, others: []),
+      ];
+
+      final validation = (
+        crossValidators: validators,
+        parsedFieldAccessorFactory: ParsedFieldAccessor.new,
+      );
+
+      expect(
+        () => CrossFieldValidationExecutor(validation).execute(
+          succesfullyParsedValues: {},
+          schema: {},
+        ),
+        throwsA(isA<FieldNotInSchemaAccessorException>()),
+      );
+    });
+  });
+}

--- a/test/src/base/zodart_exceptions_test.dart
+++ b/test/src/base/zodart_exceptions_test.dart
@@ -1,5 +1,5 @@
 import 'package:test/test.dart';
-import 'package:zodart/src/base/zodart_internal_exception.dart';
+import 'package:zodart/src/base/zodart_exceptions.dart';
 import 'package:zodart/src/z_base_config/z_base_config.dart';
 
 void main() {

--- a/test/src/types/z_object_test.dart
+++ b/test/src/types/z_object_test.dart
@@ -1,4 +1,6 @@
 import 'package:test/test.dart';
+import 'package:zodart/src/base/cross_field_validation.dart' show FieldNotInSchemaAccessorException;
+import 'package:zodart/src/base/zodart_exceptions.dart' show ZConsumerCausedException;
 import 'package:zodart/zodart.dart';
 
 import '../../test_helper.dart';
@@ -22,6 +24,15 @@ ZSchema schema = {
 };
 
 typedef SimpleRec = ({String val});
+
+/// Helper class to test cross-field validation
+class TypedFieldAccessor extends ParsedFieldAccessor {
+  TypedFieldAccessor(super.schema, super.parsedValues);
+
+  int get id => this['id'] as int;
+
+  String get name => this['name'] as String;
+}
 
 void main() {
   group('parse', () {
@@ -477,6 +488,101 @@ void main() {
         ),
         zObj.optional().onNull(onNullaFallback),
       );
+    });
+  });
+
+  group('Cross-field validation', () {
+    final zIssue1 = ZIssue.custom(message: 'issue1', rawPath: ZPath.property('id'));
+
+    ({int id, String name}) fromJson(Map<String, dynamic> json) => (id: json['id'], name: json['name']);
+
+    final schema = <String, ZBase<dynamic>>{'id': ZInt().min(1), 'name': ZString().min(1)};
+
+    test('Throws FieldNotInSchemaAccessorException when accessing a field not in schema', () {
+      SuperRefinerErrorRes? invalidFieldAccessValidator(ParsedFieldAccessor fieldValues) =>
+          (fieldValues['dummy'] as int) < 10 ? null : (zIssue1, others: []);
+
+      final zObject = ZObject.withMapper(
+        schema,
+        fromJson: fromJson,
+        crossValidators: [invalidFieldAccessValidator],
+      );
+
+      expect(
+        () => zObject.parse({'id': 100, 'name': ''}),
+        throwsA(
+          isA<FieldNotInSchemaAccessorException>()
+              .having((e) => e.fieldName, 'Field name', 'dummy')
+              .having((e) => e.schemaFieldNames, 'Schema field names', equals(['id', 'name']))
+              .having((e) => e, 'Exception extends ZConsumerCausedException', isA<ZConsumerCausedException>()),
+        ),
+      );
+    });
+
+    group('withMapper', () {
+      SuperRefinerErrorRes? isIdLowerThan10(ParsedFieldAccessor fieldValues) =>
+          (fieldValues['id'] as int) < 10 ? null : (zIssue1, others: []);
+
+      test('parsing with cross validation returns issues for the field with issues for other fields', () {
+        final res = ZObject.withMapper(
+          schema,
+          fromJson: fromJson,
+          crossValidators: [isIdLowerThan10],
+        ).parse({'id': 100, 'name': ''});
+
+        expect(res.rawIssues, isA<List<ZIssue>>().having((issues) => issues.length, 'Number of issues', 2));
+        expect(res.getRawIssuesFor('id'), equals([zIssue1]));
+      });
+
+      test('if the field used in the cross-validator is not parsed properly that issue is returned instead', () {
+        final res = ZObject.withMapper(
+          schema,
+          fromJson: fromJson,
+          crossValidators: [isIdLowerThan10],
+        ).parse({'id': 0, 'name': ''});
+
+        expect(res.rawIssues, isA<List<ZIssue>>().having((issues) => issues.length, 'Number of issues', 2));
+        expect(
+          res.getRawIssuesFor('id'),
+          isA<List<ZIssue>>()
+              .having((issues) => issues.length, 'Number of issues for id', 1)
+              .having((issues) => issues.first, 'The issue type is ZIssueMinNotMet', isA<ZIssueMinNotMet>()),
+        );
+      });
+    });
+
+    group('withTypedCrossFieldValidation', () {
+      SuperRefinerErrorRes? isIdLowerThan10(TypedFieldAccessor fieldValues) =>
+          fieldValues.id < 10 ? null : (zIssue1, others: []);
+
+      test('parsing with cross validation returns issues for the field with issues for other fields', () {
+        final res = ZObject.withTypedCrossFieldValidation(
+          schema,
+          fromJson: fromJson,
+          crossValidators: [isIdLowerThan10],
+          parsedFieldAccessorFactory: TypedFieldAccessor.new,
+        ).parse({'id': 100, 'name': ''});
+
+        expect(res.rawIssues, isA<List<ZIssue>>().having((issues) => issues.length, 'Number of issues', 2));
+        expect(res.getRawIssuesFor('id'), equals([zIssue1]));
+      });
+
+      test('if the field used in the cross-validator is not parsed properly that issue is returned instead', () {
+        final res = ZObject.withTypedCrossFieldValidation(
+          schema,
+          fromJson: fromJson,
+          crossValidators: [isIdLowerThan10],
+          parsedFieldAccessorFactory: TypedFieldAccessor.new,
+        ).parse({'id': 0, 'name': ''});
+
+        expect(res.rawIssues, isA<List<ZIssue>>().having((issues) => issues.length, 'Number of issues', 2));
+        expect(
+          res.getRawIssuesFor('id'),
+          isA<List<ZIssue>>()
+              .having((issues) => issues.length, 'Number of issues for id', 1)
+              .having((issues) => issues.first, 'The issue type is ZIssueMinNotMet', isA<ZIssueMinNotMet>()),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## 📌 Summary

To enable a validation before the object is constructed (`.refine / .superRefine`) a cross validation can be added when constructing ZObject.
 
## ✅ Changes

- [x] Add cross-field validation for ZObject

## 📝 Changelog

Changelog updated:

- [x] Yes
- [ ] No

## 🔍 Related Issues

<!-- Link to related issues, e.g. -->

Closes #101 

## 🧪 Testing

- [x] Unit tests added/updated

<!-- Explain testing strategy if needed -->

> Example: Passed all unit tests.

## 🚨 Breaking Changes

- [ ] Yes
- [x] No

If yes, describe:

## 📸 Screenshots / Videos (Optional)

None

<!-- Add before/after screenshots or videos if relevant -->

## 📓 Notes for Reviewers (Optional)

None

<!-- Any special instructions or things to look out for -->
