### PR TITLE
Feature/53 turn off lint for autogenerated files

### DIFF
--- a/example/freezed_integration/freezed_integration.zodart.dart
+++ b/example/freezed_integration/freezed_integration.zodart.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'freezed_integration.dart';
 
 // **************************************************************************

--- a/example/localization/localization.zodart.dart
+++ b/example/localization/localization.zodart.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'localization.dart';
 
 // **************************************************************************

--- a/example/localization/localization.zodart.type.dart
+++ b/example/localization/localization.zodart.type.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'localization.dart';
 
 // **************************************************************************

--- a/example/main.zodart.dart
+++ b/example/main.zodart.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'main.dart';
 
 // **************************************************************************

--- a/example/main.zodart.type.dart
+++ b/example/main.zodart.type.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'main.dart';
 
 // **************************************************************************

--- a/example/output_record/output_record.zodart.dart
+++ b/example/output_record/output_record.zodart.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'output_record.dart';
 
 // **************************************************************************

--- a/example/refine_method/refine_method.zodart.dart
+++ b/example/refine_method/refine_method.zodart.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'refine_method.dart';
 
 // **************************************************************************

--- a/example/refine_method/refine_method.zodart.type.dart
+++ b/example/refine_method/refine_method.zodart.type.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'refine_method.dart';
 
 // **************************************************************************

--- a/example/schema_embedding/schema_embedding.zodart.dart
+++ b/example/schema_embedding/schema_embedding.zodart.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'schema_embedding.dart';
 
 // **************************************************************************

--- a/example/schema_embedding/schema_embedding.zodart.type.dart
+++ b/example/schema_embedding/schema_embedding.zodart.type.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'schema_embedding.dart';
 
 // **************************************************************************

--- a/example/simple_compose/simple_compose.zodart.dart
+++ b/example/simple_compose/simple_compose.zodart.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'simple_compose.dart';
 
 // **************************************************************************

--- a/example/simple_compose/simple_compose.zodart.type.dart
+++ b/example/simple_compose/simple_compose.zodart.type.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'simple_compose.dart';
 
 // **************************************************************************

--- a/example/transformations/transformations.zodart.dart
+++ b/example/transformations/transformations.zodart.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'transformations.dart';
 
 // **************************************************************************

--- a/example/transformations/transformations.zodart.type.dart
+++ b/example/transformations/transformations.zodart.type.dart
@@ -1,6 +1,9 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart format width=80
 
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'transformations.dart';
 
 // **************************************************************************

--- a/lib/src/code_generation/builders/header.dart
+++ b/lib/src/code_generation/builders/header.dart
@@ -1,0 +1,8 @@
+/// Comment added to the beginning of generated files
+///
+/// Used to turn off linter and coverage for generated files
+const header = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+''';

--- a/lib/src/code_generation/builders/pre_type_builder.dart
+++ b/lib/src/code_generation/builders/pre_type_builder.dart
@@ -4,16 +4,21 @@ import 'package:source_gen/source_gen.dart' show PartBuilder;
 import '../ctor/_ctor.dart';
 import '../generators/pre_type_generator/pre_type_generator.dart';
 import '../schema_parsing/schema_parsing.dart';
+import 'header.dart';
 
 /// Builder which generates empty 'shells' for new types to be used in other builders.
-Builder preTypeBuilder(BuilderOptions options) => PartBuilder(const [
-  PreTypeGenerator(
-    annotationParser: ZodArtAnnotation.fromAnnotatedElement,
-    schemaErrorFormatter: SchemaParsingErrorFormatter(),
-    schemaParser: SchemaParser(
-      zTypeConverter: ZTypeConverter(),
-      ctorElementsExtractor: getPublicCtorElements,
-      ctorPicker: pickBestCtor,
+Builder preTypeBuilder(BuilderOptions options) => PartBuilder(
+  const [
+    PreTypeGenerator(
+      annotationParser: ZodArtAnnotation.fromAnnotatedElement,
+      schemaErrorFormatter: SchemaParsingErrorFormatter(),
+      schemaParser: SchemaParser(
+        zTypeConverter: ZTypeConverter(),
+        ctorElementsExtractor: getPublicCtorElements,
+        ctorPicker: pickBestCtor,
+      ),
     ),
-  ),
-], '.zodart.type.dart');
+  ],
+  '.zodart.type.dart',
+  header: header,
+);

--- a/lib/src/code_generation/builders/zodart_builder.dart
+++ b/lib/src/code_generation/builders/zodart_builder.dart
@@ -4,16 +4,21 @@ import 'package:source_gen/source_gen.dart';
 import '../ctor/ctor_picker.dart';
 import '../generators/zodart_generator/zodart_generator.dart';
 import '../schema_parsing/schema_parsing.dart';
+import 'header.dart';
 
 /// ZodArt builder
-Builder zodArtBuilder(BuilderOptions options) => PartBuilder(const [
-  ZodArtGenerator(
-    annotationParser: ZodArtAnnotation.fromAnnotatedElement,
-    schemaErrorFormatter: SchemaParsingErrorFormatter(),
-    schemaParser: SchemaParser(
-      zTypeConverter: ZTypeConverter(),
-      ctorElementsExtractor: getPublicCtorElements,
-      ctorPicker: pickBestCtor,
+Builder zodArtBuilder(BuilderOptions options) => PartBuilder(
+  const [
+    ZodArtGenerator(
+      annotationParser: ZodArtAnnotation.fromAnnotatedElement,
+      schemaErrorFormatter: SchemaParsingErrorFormatter(),
+      schemaParser: SchemaParser(
+        zTypeConverter: ZTypeConverter(),
+        ctorElementsExtractor: getPublicCtorElements,
+        ctorPicker: pickBestCtor,
+      ),
     ),
-  ),
-], '.zodart.dart');
+  ],
+  '.zodart.dart',
+  header: header,
+);

--- a/lib/src/code_generation/generators/base_generator_for_annotation.dart
+++ b/lib/src/code_generation/generators/base_generator_for_annotation.dart
@@ -38,16 +38,6 @@ abstract class BaseGeneratorForAnnotation extends GeneratorForAnnotation<ZodArt>
   /// Utility to obtain human-readable errors produced by [SchemaParser].
   final SchemaParsingErrorFormatter schemaErrorFormatter;
 
-  /// Comment added to the beginning of generated files
-  ///
-  /// Used to turn off linter and coverage for generated files
-  static const _fileHeaderComment = '''
-// GENERATED CODE - DO NOT MODIFY BY HAND
-// coverage:ignore-file
-// ignore_for_file: type=lint
-
-''';
-
   /// Builds the list of code specifications (`Spec`) to be generated.
   ///
   /// Called during [generateForAnnotatedElement] after the annotation and schema
@@ -80,8 +70,7 @@ abstract class BaseGeneratorForAnnotation extends GeneratorForAnnotation<ZodArt>
     final specs = buildSpecs(parseResult);
 
     final emitter = DartEmitter();
-    final specsOutput = specs.map((spec) => spec.accept(emitter)).join(' ');
-    final output = specsOutput.isNotEmpty ? _fileHeaderComment + specsOutput : '';
+    final output = specs.map((spec) => spec.accept(emitter)).join(' ');
 
     // Returns the generated code
     return DartFormatter(

--- a/test/src/code_generation/generators/all_types/goldens/pretype_new_class.dart
+++ b/test/src/code_generation/generators/all_types/goldens/pretype_new_class.dart
@@ -1,8 +1,4 @@
 part of '../pretype_src.dart';
 
-// GENERATED CODE - DO NOT MODIFY BY HAND
-// coverage:ignore-file
-// ignore_for_file: type=lint
-
 /// Class used as an output for [N.schema].
 abstract final class NewClass with _N {}

--- a/test/src/code_generation/generators/all_types/goldens/zodart_existing_class.dart
+++ b/test/src/code_generation/generators/all_types/goldens/zodart_existing_class.dart
@@ -1,9 +1,5 @@
 part of '../zodart_src.dart';
 
-// GENERATED CODE - DO NOT MODIFY BY HAND
-// coverage:ignore-file
-// ignore_for_file: type=lint
-
 /// Inferred Dart type returned from the schema defined in [E].
 ///
 /// This corresponds to the structure described by [E.schema].

--- a/test/src/code_generation/generators/all_types/goldens/zodart_new_class.dart
+++ b/test/src/code_generation/generators/all_types/goldens/zodart_new_class.dart
@@ -1,9 +1,5 @@
 part of '../zodart_src.dart';
 
-// GENERATED CODE - DO NOT MODIFY BY HAND
-// coverage:ignore-file
-// ignore_for_file: type=lint
-
 /// Inferred Dart type returned from the schema defined in [N].
 ///
 /// This corresponds to the structure described by [N.schema].

--- a/test/src/code_generation/generators/all_types/goldens/zodart_record.dart
+++ b/test/src/code_generation/generators/all_types/goldens/zodart_record.dart
@@ -1,9 +1,5 @@
 part of '../zodart_src.dart';
 
-// GENERATED CODE - DO NOT MODIFY BY HAND
-// coverage:ignore-file
-// ignore_for_file: type=lint
-
 /// Inferred Dart type returned from the schema defined in [R].
 ///
 /// This corresponds to the structure described by [R.schema].


### PR DESCRIPTION
## 📌 Summary

Add a comment to beginning of generated files to turn off linter and test coverage. Fixes #103 

## ✅ Changes

- [x] Turn off linter & test coverage for generated files

## 📝 Changelog

Changelog updated:

- [ ] Yes
- [x] No

Updated in previous PR.

## 🔍 Related Issues

<!-- Link to related issues, e.g. -->

Closes #53  
Related to #103 

## 🧪 Testing

- [x] Unit tests added/updated

<!-- Explain testing strategy if needed -->

> Example: Passed all unit tests.

## 🚨 Breaking Changes

- [ ] Yes
- [x] No

If yes, describe:

## 📸 Screenshots / Videos (Optional)

None

<!-- Add before/after screenshots or videos if relevant -->

## 📓 Notes for Reviewers (Optional)

This is basically a replacement for #103 
