### PR TITLE
fix: return an expression instead of assignment in get pathStr

### DIFF
--- a/lib/src/base/z_path.dart
+++ b/lib/src/base/z_path.dart
@@ -40,7 +40,7 @@ abstract class ZPath with _$ZPath {
   String? get pathStr {
     if (path.isEmpty) return null;
 
-    return path.foldLeftWithIndex<String>('', (curr, item, index) => curr += _formatPathSegment(item, index == 0));
+    return path.foldLeftWithIndex<String>('', (curr, item, index) => curr + _formatPathSegment(item, index == 0));
   }
 
   /// Adds a path item to the beginning of this path.


### PR DESCRIPTION
## 📌 Summary

Fix analyzer issues for Dart 3.11.

## ✅ Changes

- [x] Fix `info - lib/src/base/z_path.dart:43:70 - Invalid assignment to the parameter 'curr'. Try using a local variable in place of the parameter. - parameter_assignments`

## 📝 Changelog

Changelog updated:

- [ ] Yes
- [x] No - not needed

## 🔍 Related Issues

<!-- Link to related issues, e.g. -->

Closes #116 

## 🧪 Testing

- [x] Unit tests added/updated - no update needed

<!-- Explain testing strategy if needed -->

> Example: Passed all unit tests.

## 🚨 Breaking Changes

- [ ] Yes
- [x] No

If yes, describe:

## 📸 Screenshots / Videos (Optional)

None

<!-- Add before/after screenshots or videos if relevant -->

## 📓 Notes for Reviewers (Optional)

None

<!-- Any special instructions or things to look out for -->
